### PR TITLE
Have Connect() return error instead of log.Fatal

### DIFF
--- a/cmd/callmon-example/main.go
+++ b/cmd/callmon-example/main.go
@@ -30,7 +30,10 @@ func mainloop(host string) {
 
 	recv := make(chan fritzbox.FbEvent)
 
-	c := new(fritzbox.CallmonHandler).Connect(host, recv)
+	c, err := new(fritzbox.CallmonHandler).Connect(host, recv)
+	if err != nil {
+		return
+	}
 
 	defer c.Close()
 

--- a/fritzbox/fritzbox.go
+++ b/fritzbox/fritzbox.go
@@ -44,28 +44,30 @@ func (e FbEvent) String() string {
 	return fmt.Sprintf("Event %s: %s", e.Timestamp, e.EventName)
 }
 
-func (c CallmonHandler) Connect(host string, recv chan FbEvent) CallmonHandler {
+func (c CallmonHandler) Connect(host string, recv chan FbEvent) (CallmonHandler, error) {
 	c.Host = host
 	c.event = recv
 
 	addr, err := net.ResolveTCPAddr("tcp", host+":1012")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		c.Connected = false
+		return c, err
 	}
 
 	conn, err := net.DialTCP("tcp", nil, addr)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 		c.Connected = false
-	} else {
-		c.Connected = true
+		return c, err
 	}
+	c.Connected = true
 
 	conn.SetKeepAlivePeriod(time.Duration(30) * time.Second)
 	conn.SetKeepAlive(true)
 
 	c.conn = conn
-	return c
+	return c, nil
 }
 
 func (c CallmonHandler) Close() {


### PR DESCRIPTION
log.Fatal exits the running process, which makes this function terminate
the whole application if the connection could not be established.

Instead of log.Fatal, Connect() now returns the error to the caller
for further handling.